### PR TITLE
INTERAC-14 improve nginx config & clean up

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -6,11 +6,8 @@ FROM python:3.6.0-alpine
 RUN mkdir -p /deploy/app/blueprints \
   && mkdir -p /deploy/app/static \
   && mkdir -p /deploy/app/templates
+
 COPY app/requirements.txt /deploy/app/
-COPY app/*.py /deploy/app/
-COPY app/blueprints /deploy/app/blueprints
-COPY app/static /deploy/app/static
-COPY app/templates /deploy/app/templates
 
 RUN apk add --no-cache --update python3 \
   && python3 -m ensurepip \
@@ -26,6 +23,11 @@ RUN apk add --no-cache --update python3 \
     build-base python3-dev \
   && apk add logrotate \
   && rm -rf /var/cache/apk/*
+
+COPY app/*.py /deploy/app/
+COPY app/blueprints /deploy/app/blueprints
+COPY app/static /deploy/app/static
+COPY app/templates /deploy/app/templates
 
 # Setup nginx
 RUN mkdir -p /run/nginx \

--- a/server/flask.conf
+++ b/server/flask.conf
@@ -6,17 +6,22 @@ server {
       return 301 https://$host$request_uri;
     }
 
-    location / {
-        proxy_pass http://127.0.0.1:5000/;
-        proxy_set_header Host $host;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    }
-
     # Disable access logging on the health check URL
     location /health {
         proxy_pass http://127.0.0.1:5000/health;
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         access_log off;
+    }
+
+    location /static {
+        autoindex on;
+        alias /deploy/app/static/;
+    }
+
+    location / {
+        proxy_pass http://127.0.0.1:5000/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
 }

--- a/server/nginx.conf
+++ b/server/nginx.conf
@@ -1,13 +1,5 @@
 
-#user  nobody;
 worker_processes  1;
-
-#error_log  logs/error.log;
-#error_log  logs/error.log  notice;
-#error_log  logs/error.log  info;
-
-#pid        run/nginx.pid;
-
 
 events {
     worker_connections  1024;
@@ -18,34 +10,18 @@ http {
     include       mime.types;
     default_type  application/octet-stream;
 
-    #log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
-    #                  '$status $body_bytes_sent "$http_referer" '
-    #                  '"$http_user_agent" "$http_x_forwarded_for"';
-
-    #access_log  logs/access.log  main;
 
     sendfile        on;
-    #tcp_nopush     on;
-
-    #keepalive_timeout  0;
     keepalive_timeout  65;
-
-    #gzip  on;
 
     server {
         listen       80;
         server_name  localhost;
 
-        #charset koi8-r;
-
-        #access_log  logs/host.access.log  main;
-
         location / {
             root   html;
             index  index.html index.htm;
         }
-
-        #error_page  404              /404.html;
 
         # redirect server error pages to the static page /50x.html
         #
@@ -54,70 +30,11 @@ http {
             root   html;
         }
 
-        # proxy the PHP scripts to Apache listening on 127.0.0.1:80
-        #
-        #location ~ \.php$ {
-        #    proxy_pass   http://127.0.0.1;
-        #}
-
-        # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
-        #
-        #location ~ \.php$ {
-        #    root           html;
-        #    fastcgi_pass   127.0.0.1:9000;
-        #    fastcgi_index  index.php;
-        #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
-        #    include        fastcgi_params;
-        #}
-
-        # deny access to .htaccess files, if Apache's document root
-        # concurs with nginx's one
-        #
-        #location ~ /\.ht {
-        #    deny  all;
-        #}
-
         location ^~ /static/ {
             include  /etc/nginx/mime.types;
             root /deploy/app/;
         }
     }
-
-
-    # another virtual host using mix of IP-, name-, and port-based configuration
-    #
-    #server {
-    #    listen       8000;
-    #    listen       somename:8080;
-    #    server_name  somename  alias  another.alias;
-
-    #    location / {
-    #        root   html;
-    #        index  index.html index.htm;
-    #    }
-    #}
-
-
-    # HTTPS server
-    #
-    #server {
-    #    listen       443 ssl;
-    #    server_name  localhost;
-
-    #    ssl_certificate      cert.pem;
-    #    ssl_certificate_key  cert.key;
-
-    #    ssl_session_cache    shared:SSL:1m;
-    #    ssl_session_timeout  5m;
-
-    #    ssl_ciphers  HIGH:!aNULL:!MD5;
-    #    ssl_prefer_server_ciphers  on;
-
-    #    location / {
-    #        root   html;
-    #        index  index.html index.htm;
-    #    }
-    #}
 
     include /etc/nginx/conf.d/*.conf;
     include /etc/nginx/sites-enabled/*;


### PR DESCRIPTION
While debugging dev-demo.na.bambora.com I had simplified a few
things in the nginx.conf file & Dockerfile.  Might as well commit
these changes.

The only behavioural change is that /static is now served by nginx
instead of going through the gunicorn proxy.  This is an efficiency
gain as it means instead of going through the app server, requests
for static assets are just straight file returns (no processing so
reduces server load).  It also helps with debugging as you can then
fire up a Docker container locally & try going to 
/static/images/android-pay.png and if you see an image, you know
nginx is set up right and requests are getting that far.  If you go
to /health or / and it times out, then you know the problem is
somewhere between nginx and Flask.