### PR TITLE
INTERAC-21 fix getting url on apple pay session endpoint

### DIFF
--- a/server/app/server.py
+++ b/server/app/server.py
@@ -105,14 +105,13 @@ def route(path):
 # Accept a POST to /getApplePaySession
 @app.route('/getApplePaySession', methods=["POST"])
 def get_apple_pay_session():
-        # Must contain apple url from onMerchantValidate event
-        url = request.form["url"]
-        #merchant ID, domain name, and display name
-        body = jsonify(merchantIdentifier=merchant_identifier,
-                        domainName=merchant_domain,
-                        displayName='Payments Demo')
-        r = requests.post(url, cert=('merchant_id.cer'), data=body)
-        return r
+    # Must contain apple url from onMerchantValidate event
+    url = request.get_json().get("url")
+    body = jsonify(merchantIdentifier=merchant_identifier,
+                   domainName=merchant_domain,
+                   displayName='Payments Demo')
+    r = requests.post(url, cert=('merchant_id.cer'), data=body)
+    return r
 
 app.register_blueprint(basic, url_prefix='/payment/basic')
 app.register_blueprint(card, url_prefix='/payment/card')


### PR DESCRIPTION
This doesn't fix the problem with getting the Apple Pay token, but is a step in the right direction.  We had been pulling out the URL passed to ```/getApplePaySession``` from a form POST instead of as json data.  This fixes that, but now leads to a new SSL problem that's the next thing to debug/figure out.