### PR TITLE
INTERAC-21 fix domain for Bamboo

### DIFF
--- a/JenkinsFile
+++ b/JenkinsFile
@@ -1,15 +1,17 @@
 #!groovy
 
 DEPLOY = true
-DOMAIN = 'dev-demo.na.bambora.com'
+DOMAIN = 'demo.na.bambora.com'
 if("$BRANCH_NAME" == 'develop') {
     ENV = 'dev-cde'
+    DOMAIN = 'dev-demo.na.bambora.com'
 } else if("$BRANCH_NAME" == 'master') {
     ENV = 'prod-cde'
     DOMAIN = 'demo.na.bambora.com'
 } else {
     DEPLOY = false
     ENV = 'dev-cde'
+    DOMAIN = 'dev-demo.na.bambora.com'
 }
 
 REGION = 'ca-central-1'

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -2,7 +2,7 @@
 
 FROM python:3.6.0-alpine
 
-ARG domain=dev-demo.na.bambora.com
+ARG domain=demo.na.bambora.com
 
 # Install platform dependencies & setup flask application
 RUN mkdir -p /deploy/app/blueprints \

--- a/server/app/static/scripts/apple-pay-ctrl.js
+++ b/server/app/static/scripts/apple-pay-ctrl.js
@@ -119,6 +119,9 @@ function applePayButtonClicked() {
         // Send payment for processing...
         const payment = event.payment;
 
+        console.log("Full Payment object: ", payment);
+        console.log("Token: ", payment.token.paymentData.data);
+
         // ...return a status and redirect to a confirmation page
         session.completePayment(ApplePaySession.STATUS_SUCCESS);
     }


### PR DESCRIPTION
Previously we committed the domain association file for dev-demo and demo,
and set up Jenkins to use the file for dev-demo (since dev-demo is deployed
to by Jenkins).  This meant however that when Bamboo builds the master branch
it still also uses the same domain association file for dev demo (incorrectly).
This change makes it so that the default is the domain association file for
demo is used, and Jenkins specifies the dev-demo association file explicitly
when the branch isn't master.

Also since I was updating anyways, I decided to log the token & payment
object for testing/verification purposes.