### PR TITLE
INTERAC-21 delete master branch builds in Jenkinsfile

### DIFF
--- a/JenkinsFile
+++ b/JenkinsFile
@@ -5,9 +5,6 @@ DOMAIN = 'demo.na.bambora.com'
 if("$BRANCH_NAME" == 'develop') {
     ENV = 'dev-cde'
     DOMAIN = 'dev-demo.na.bambora.com'
-} else if("$BRANCH_NAME" == 'master') {
-    ENV = 'prod-cde'
-    DOMAIN = 'demo.na.bambora.com'
 } else {
     DEPLOY = false
     ENV = 'dev-cde'


### PR DESCRIPTION
There are no workers currently on non-prod Jenkins that can build prod-cde, so this block results in hung builds on jenkins.na.bambora.com until someone manually kills them.  I've had to do this a number of times now, so I'm removing this section from the Jenkinsfile.

Given that when we do migrate this project to do prod deployments in Jenkins instead of Bamboo, we'll have to have a separate Jenkinsfile to target prod Jenkins, there's no point in having any special treatment of the master branch in the current Jenkinsfile.